### PR TITLE
Remove check for AZD and bicep

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -18,13 +18,6 @@ def check_not_implemented() -> None:
         )
 
 
-def tests_bicep_is_installed():
-    """Tests that bicep is installed"""
-
-    bicep_check = subprocess.run(["az", "bicep", "version"], capture_output=True)
-
-
-
 if __name__ == "__main__":
     check_not_implemented()
-    tests_bicep_is_installed()
+


### PR DESCRIPTION
This pull request removes the check for AZD and bicep as they provide conflicting guidance. The check for bicep installation has been removed from the code. This resolves issue #1.