### PR TITLE
Remove echo from FastAPI

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/models.py
@@ -22,7 +22,7 @@ sql_url = f"postgresql://{POSTGRES_USERNAME}:{POSTGRES_PASSWORD}@{POSTGRES_HOST}
 if POSTGRES_SSL:
     sql_url = f"{sql_url}?sslmode={POSTGRES_SSL}"
 
-engine = create_engine(sql_url, echo=True)
+engine = create_engine(sql_url)
 
 
 def create_db_and_tables():


### PR DESCRIPTION
This pull request removes the echo parameter from the create_engine function in FastAPI. The echo parameter was set to True, causing the SQL queries to be printed to the console. Removing this parameter ensures that the SQL queries are not printed during runtime. Fixes #3

I thought were was another location that echo was called for FastAPI but I must have been mistaken.