### PR TITLE
Change path for cookiecutter source

### DIFF
--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -183,6 +183,7 @@ def update_repo(
     if force:
         with open(path.joinpath(".cruft.json"), "r") as f:
             extra_context=json.loads(f.read())["context"]["cookiecutter"]
+            logger.info(f"{extra_context=}")
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -182,13 +182,14 @@ def update_repo(
     
     if force:
         with open(path.joinpath(".cruft.json"), "r") as f:
-            extra_context=json.loads(f.read())["context"]["cookiecutter"]
-            extra_context['cookiecutter']['project_name'] = "azure"
-            logger.info(f"{extra_context=}")
+            extra_context=json.loads(f.read()["context"]["cookiecutter"])
+            extra_context={ec_key:val for ec_key, val in extra_context.items() if not ec_Key.startswith("_")}
+        extra_context['project_name'] = "azure"
+        logger.info(f"{extra_context=}")
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")
-        cruft.create(source, output_dir=path.parent, extra_context=extra_context,no_input=True, overwrite_if_exists=True)
+        cruft.create(source, output_dir=path.parent, extra_context=extra_context, no_input=True, overwrite_if_exists=True)
         subprocess.check_output(
             ["git", "add", "."],
             text=True,

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -270,7 +270,7 @@ def update_repos(
     source: Annotated[str, typer.Option(
         "--source",
         "-s",
-        help="The source to use for cruft updates `source` parameter.",
+        help="The source to use for cruft updates `source` parameter. Setting this will change the .cruft.json file to use the provided source permanently.",
     )]=None,
 ) -> None:
 

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -181,10 +181,12 @@ def update_repo(
     )
     
     if force:
+        with open(path.joinpath(".cruft.json"), "r") as f:
+            extra_context=json.loads(f.read())["cookiecutter"]
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")
-        cruft.link(source, project_dir=path,)
+        cruft.create(source, project_dir=path, extra_context=extra_context, skip_apply_ask=True, overwrite_if_exists=True)
         subprocess.check_output(
             ["git", "add", "."],
             text=True,
@@ -196,12 +198,13 @@ def update_repo(
             cwd=path,
         )
 
-    cruft.update(
-        path,
-        skip_apply_ask=True,
-        extra_context=kwargs,
-        checkout=checkout if checkout else None,
-    )
+    else:
+        cruft.update(
+            path,
+            skip_apply_ask=True,
+            extra_context=kwargs,
+            checkout=checkout if checkout else None,
+        )
 
     if not subprocess.check_output(
         ["git", "status", "--porcelain"],

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -183,6 +183,16 @@ def update_repo(
     if force:
         path.joinpath(".cruft.json").unlink()
         cruft.link(source, project_dir=path,)
+        subprocess.check_output(
+            ["git", "add", "."],
+            text=True,
+            cwd=path,
+        )
+        subprocess.check_output(
+            ["git", "commit", "-m", "remove cruft.json"],
+            text=True,
+            cwd=path,
+        )
 
     cruft.update(
         path,

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -182,7 +182,7 @@ def update_repo(
     
     if force:
         with open(path.joinpath(".cruft.json"), "r") as f:
-            extra_context=json.loads(f.read())["cookiecutter"]
+            extra_context=json.loads(f.read())["context"]["cookiecutter"]
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -182,9 +182,9 @@ def update_repo(
     
     if force:
         with open(path.joinpath(".cruft.json"), "r") as f:
-            extra_context=json.loads(f.read()["context"]["cookiecutter"])
-            extra_context={ec_key:val for ec_key, val in extra_context.items() if not ec_Key.startswith("_")}
-        extra_context['project_name'] = "azure"
+            extra_context=json.loads(f.read())["context"]["cookiecutter"]
+            extra_context={ec_key:val for ec_key, val in extra_context.items() if not ec_key.startswith("_")}
+        extra_context['__src_folder_name'] = repo 
         logger.info(f"{extra_context=}")
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -4,7 +4,7 @@ import logging
 import pathlib
 import subprocess
 import random
-from typing import Generator, Optional
+from typing import Generator
 import typer
 import re
 import json

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -183,6 +183,7 @@ def update_repo(
     if force:
         with open(path.joinpath(".cruft.json"), "r") as f:
             extra_context=json.loads(f.read())["context"]["cookiecutter"]
+            extra_context['cookiecutter']['project_name'] = "azure"
             logger.info(f"{extra_context=}")
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -186,7 +186,7 @@ def update_repo(
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")
-        cruft.create(source, output_dir=path, extra_context=extra_context, skip_apply_ask=True, overwrite_if_exists=True)
+        cruft.create(source, output_dir=path.parent, extra_context=extra_context,no_input=True, overwrite_if_exists=True)
         subprocess.check_output(
             ["git", "add", "."],
             text=True,

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -186,7 +186,7 @@ def update_repo(
         logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
         logger.info(f"Linking {source} to {path}")
-        cruft.create(source, project_dir=path, extra_context=extra_context, skip_apply_ask=True, overwrite_if_exists=True)
+        cruft.create(source, output_dir=path, extra_context=extra_context, skip_apply_ask=True, overwrite_if_exists=True)
         subprocess.check_output(
             ["git", "add", "."],
             text=True,

--- a/tools/update_info.py
+++ b/tools/update_info.py
@@ -181,7 +181,9 @@ def update_repo(
     )
     
     if force:
+        logger.info(f"Removing cruft.json from {path}")
         path.joinpath(".cruft.json").unlink()
+        logger.info(f"Linking {source} to {path}")
         cruft.link(source, project_dir=path,)
         subprocess.check_output(
             ["git", "add", "."],
@@ -272,7 +274,7 @@ def update_repos(
     patterns = get_repos_by_pattern(pattern)
     patterns_str = '\n- '.join(patterns)
     logger.info(f"Found {len(patterns)} repos matching \"{pattern}\"\n{patterns_str}")
-    force = source != None
+    force = source is not None
 
     for repo in patterns:
         update_repo(repo=repo, path=path, branch=branch, checkout=checkout, submit_pr=submit_pr, source=source, force=force)


### PR DESCRIPTION
This pull request updates the path for the cookiecutter source in the CLI. The old repository is being replaced with the new repository. This change fixes issue #10.

Also fixes #7 by making the repos not submit prs unless the `--submit-prs` flag is set.