### PR TITLE
[FIX] adds changes to multiple OS's

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/.github/workflows/test_postgres.yml
+++ b/{{cookiecutter.__src_folder_name}}/.github/workflows/test_postgres.yml
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Check for MacOS Runner
+        if: matrix.os == 'macos-latest-xlarge'
+        run: brew install postgresql@14
       - name: Setup postgres
         uses: ikalnytskyi/action-setup-postgres@v4
       - name: Setup python

--- a/{{cookiecutter.__src_folder_name}}/src/requirements.txt
+++ b/{{cookiecutter.__src_folder_name}}/src/requirements.txt
@@ -13,6 +13,6 @@ whitenoise
 opencensus-ext-azure
 opencensus-ext-django
 {% if 'postgres' in cookiecutter.db_resource %}
-psycopg2-binary==2.9.6
+psycopg2
 {% endif %}
 {% endif %}


### PR DESCRIPTION
updates the requirements to switch to just psycopg2 (drops pinned version) and adds the check back into the macos latest xlarge runner