### PR TITLE
"Fix Windows tests failing due to call method being manually set to spawn"

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/pyproject.toml
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/pyproject.toml
@@ -3,13 +3,13 @@ name = "fastapi_app"
 version = "1.0.0"
 description = "{{cookiecutter.__project_short_description}}"
 dependencies = [
-    "fastapi==0.100.1",
-    "jinja2==3.1.2",
-    "uvicorn[standard]==0.23.2",
-    "python-multipart==0.0.6",
+    "fastapi",
+    "jinja2",
+    "uvicorn[standard]",
+    "python-multipart",
     {% if 'postgres' in cookiecutter.db_resource %}
-    "psycopg2-binary==2.9.6",
-    "sqlmodel==0.0.8",
+    "psycopg2",
+    "sqlmodel",
     {% endif %}
 ]
 

--- a/{{cookiecutter.__src_folder_name}}/src/tests/local/conftest.py
+++ b/{{cookiecutter.__src_folder_name}}/src/tests/local/conftest.py
@@ -12,6 +12,7 @@ import pathlib
 {% if cookiecutter.project_backend == "django" %}
 import os
 {% endif %}
+import sys
 
 {# third-party library imports #}
 import pytest
@@ -46,7 +47,8 @@ from flaskapp import db
 
 {% if cookiecutter.project_backend in ("flask", "fastapi") %}
 # Set start method to "fork" to avoid issues with pickling on OSes that default to "spawn"
-multiprocessing.set_start_method("fork")
+if sys.platform != "win32":
+    multiprocessing.set_start_method("fork")
 {% endif %}
 
 {% if cookiecutter.project_backend == "fastapi" %}


### PR DESCRIPTION
Fixes #17

This updates the code to check the operating system and use the default on windows and 'fork' on everything else

Also removes pinned versions in pyproject.toml which was causing issues with Python 3.12