### PR TITLE
Key vault IP Restriction for Cosmos apps

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/infra/core/security/keyvault.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/security/keyvault.bicep
@@ -6,7 +6,7 @@ param tags object = {}
 param principalId string = ''
 
 // Allow public network access to Key Vault
-param allowPublicNetworkAccess bool = true
+param allowPublicNetworkAccess bool = false
 
 // Allow all Azure services to bypass Key Vault network rules
 param allowAzureServicesAccess bool = true

--- a/{{cookiecutter.__src_folder_name}}/infra/core/security/keyvault.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/security/keyvault.bicep
@@ -5,6 +5,19 @@ param tags object = {}
 
 param principalId string = ''
 
+// Allow public network access to Key Vault
+param allowPublicNetworkAccess bool = true
+
+// Allow all Azure services to bypass Key Vault network rules
+param allowAzureServicesAccess bool = true
+
+param networkAcls object = {
+  bypass: allowAzureServicesAccess ? 'AzureServices' : 'None'
+  defaultAction: allowPublicNetworkAccess ? 'Allow' : 'Deny'
+  ipRules: []
+  virtualNetworkRules: []
+}
+
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   name: name
   location: location
@@ -12,6 +25,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   properties: {
     tenantId: subscription().tenantId
     sku: { family: 'A', name: 'standard' }
+    networkAcls: networkAcls
     accessPolicies: !empty(principalId) ? [
       {
         objectId: principalId

--- a/{{cookiecutter.__src_folder_name}}/infra/main.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/main.bicep
@@ -32,6 +32,9 @@ var resourceToken = toLower(uniqueString(subscription().id, name, location))
 var prefix = '${name}-${resourceToken}'
 var tags = { 'azd-env-name': name }
 
+var allowAzureServicesAccess = true
+var defaultAction = false
+
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: '${name}-rg'
   location: location
@@ -47,6 +50,10 @@ module keyVault './core/security/keyvault.bicep' = {
     location: location
     tags: tags
     principalId: principalId
+    networkAcls: {
+      allowAzureServicesAccess: allowAzureServicesAccess
+      defaultAction: defaultAction
+    }
   }
 }
 

--- a/{{cookiecutter.__src_folder_name}}/infra/main.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/main.bicep
@@ -35,6 +35,7 @@ var tags = { 'azd-env-name': name }
 var allowAzureServicesAccess = true
 var defaultAction = false
 
+
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: '${name}-rg'
   location: location
@@ -50,6 +51,7 @@ module keyVault './core/security/keyvault.bicep' = {
     location: location
     tags: tags
     principalId: principalId
+    allowPublicNetworkAccess: false
     networkAcls: {
       allowAzureServicesAccess: allowAzureServicesAccess
       defaultAction: defaultAction

--- a/{{cookiecutter.__src_folder_name}}/infra/main.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/main.bicep
@@ -52,10 +52,6 @@ module keyVault './core/security/keyvault.bicep' = {
     tags: tags
     principalId: principalId
     allowPublicNetworkAccess: false
-    networkAcls: {
-      allowAzureServicesAccess: allowAzureServicesAccess
-      defaultAction: defaultAction
-    }
   }
 }
 

--- a/{{cookiecutter.__src_folder_name}}/infra/main.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/main.bicep
@@ -32,10 +32,6 @@ var resourceToken = toLower(uniqueString(subscription().id, name, location))
 var prefix = '${name}-${resourceToken}'
 var tags = { 'azd-env-name': name }
 
-var allowAzureServicesAccess = true
-var defaultAction = false
-
-
 resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: '${name}-rg'
   location: location
@@ -51,7 +47,6 @@ module keyVault './core/security/keyvault.bicep' = {
     location: location
     tags: tags
     principalId: principalId
-    allowPublicNetworkAccess: false
   }
 }
 


### PR DESCRIPTION
Restrict access of IPs for Key Vault in Cosmos templates

As per https://github.com/Azure-Samples/Azure-Python-Standardization-Template-Generator/security/code-scanning/21