### PR TITLE
Add secure decorator to connectionStringKey

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/infra/core/database/cosmos/cosmos-account.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/database/cosmos/cosmos-account.bicep
@@ -3,6 +3,7 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 
+@secure()
 param connectionStringKey string = 'AZURE-COSMOS-CONNECTION-STRING'
 param keyVaultName string
 


### PR DESCRIPTION
Mark key string (not an actual key, variable just contains word "key") as secure in {{cookiecutter.__src_folder_name}}/infra/core/database/cosmos/cosmos-account.bicep