### PR TITLE
Enable diagnostic logging by default in app service

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/infra/core/host/appservice.bicep
+++ b/{{cookiecutter.__src_folder_name}}/infra/core/host/appservice.bicep
@@ -17,6 +17,8 @@ param runtimeName string
 param runtimeNameAndVersion string = '${runtimeName}|${runtimeVersion}'
 param runtimeVersion string
 
+param enableDiagnosticLogging bool = true
+
 // Microsoft.Web/sites Properties
 param kind string = 'app,linux'
 
@@ -58,6 +60,10 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
       cors: {
         allowedOrigins: union([ 'https://portal.azure.com', 'https://ms.portal.azure.com' ], allowedOrigins)
       }
+      // Diagnostic logging
+      detailedErrorLoggingEnabled: enableDiagnosticLogging
+      httpLoggingEnabled: enableDiagnosticLogging
+      requestTracingEnabled: enableDiagnosticLogging
     }
     clientAffinityEnabled: clientAffinityEnabled
     httpsOnly: true


### PR DESCRIPTION
See https://github.com/Azure/template-analyzer/blob/main/docs/built-in-rules.md/#ta-000001-diagnostic-logs-in-app-service-should-be-enabled