### PR TITLE
Test python 8,9,10 for Macos on Macos13 not latest

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/.github/workflows/test_postgres.yml
+++ b/{{cookiecutter.__src_folder_name}}/.github/workflows/test_postgres.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "macos-latest-xlarge", "windows-latest"]
+        os: ["ubuntu-latest", "macos-13", "macos-latest-xlarge", "windows-latest"]
         python_version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         exclude:
           - os: macos-latest-xlarge


### PR DESCRIPTION
GitHub has upped the latest version to MacOS 14, this is not compatible with Python 10 and less. Set Tests to run with MacOS 13.