### PR TITLE
Disable PSRule for ACA

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/ps-rule.yaml
+++ b/{{cookiecutter.__src_folder_name}}/ps-rule.yaml
@@ -1,3 +1,12 @@
 # YAML: Set the AZURE_BICEP_FILE_EXPANSION configuration option to enable expansion
 configuration:
   AZURE_BICEP_FILE_EXPANSION: true
+  AZURE_DEPLOYMENT_NONSENSITIVE_PARAMETER_NAMES:
+    - connectionStringKey
+
+
+rule:
+  exclude:
+  # Ignore ACA public access rules since all these templates are for public facing web apps
+  - Azure.ContainerApp.RestrictIngress
+  - Azure.ContainerApp.PublicAccess


### PR DESCRIPTION
These two rules are meaningless for public facing web apps. 