### PR TITLE
Fixing the Information Request page in the fastapi app

### DIFF
--- a/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/app.py
+++ b/{{cookiecutter.__src_folder_name}}/src/fastapi/fastapi_app/app.py
@@ -1,8 +1,9 @@
 import os
 import pathlib
+from typing import Annotated
 
 from azure.monitor.opentelemetry import configure_azure_monitor
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -54,14 +55,23 @@ def cruise_detail(request: Request, pk: int):
 
 @app.get("/info_request/", response_class=HTMLResponse)
 def info_request(request: Request):
-    return templates.TemplateResponse("info_request_create.html", {"request": request})
+    with Session(engine) as session:
+        all_cruises = session.exec(select(Cruise)).all()
+        return templates.TemplateResponse("info_request_create.html", {"request": request, "cruises": all_cruises})
 
 
 @app.post("/info_request/", response_model=InfoRequest)
-def create_info_request(info_request: InfoRequest):
+def create_info_request(request: Request, info_request: Annotated[InfoRequest, Form()]):
     with Session(engine) as session:
-        db_info_request = InfoRequest.from_orm(info_request)
-        session.add(db_info_request)
+        session.add(info_request)
         session.commit()
-        session.refresh(db_info_request)
-        return db_info_request
+        session.refresh(info_request)
+        all_cruises = session.exec(select(Cruise)).all()
+        return templates.TemplateResponse(
+            "info_request_create.html",
+            {
+                "request": request,
+                "cruises": all_cruises,
+                "message": "Information request submitted.",
+            },
+        )


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
There are presently a couple of bugs in the Information Request page of the template.

* The `info_request_create.html` template requires an array of cruises to be passed in, to populate the dropdown box, but none are. This PR fetches the cruises and passes them in.
* When submitting an info request, there is a 500 error. This is due to some incorrect typing, of parameters. Additionally, int returns a raw object. I noticed that the template has a message prop, so I made it re-render the template with a message assigned to that prop.

This maybe still isn't ideal, as there's no way to actually see the info requests from the database, so as a tutorial it can be hard to be certain that your database is writing correctly, but it's an improvement.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
Generate any FastAPI template.
Spin up the template locally, and use the Request Information page.
When you go to that page, it should now a) have cruises listed, and b) when you submit, a message should appear saying "Information request submitted."

## What to Check
Verify that the following are valid
* When you go to that page, it should now have cruises listed
* When you submit, a message should appear saying "Information request submitted."

## Other Information
<!-- Add any other helpful information that may be needed here. -->